### PR TITLE
Convenience method to create all views by naming convention

### DIFF
--- a/experts_dw/dbviews.py
+++ b/experts_dw/dbviews.py
@@ -1,3 +1,4 @@
+import sys
 import sqlparse
 
 employee_columns =  ', '.join([
@@ -296,14 +297,14 @@ CREATE OR REPLACE FORCE EDITIONABLE VIEW EXPERT.PURE_ELIGIBLE_PERSON (
   FROM pure_eligible_employee
 )'''
 
-def create_pure_eligible_demographics(session):
+def create_view_pure_eligible_demographics(session):
     result = session.execute(
         sqlparse.format(pure_eligible_demographics, reindent=True)
     )
     session.commit()
     return result
 
-def create_pure_eligible_person(session):
+def create_view_pure_eligible_person(session):
     result = session.execute(
         sqlparse.format(pure_eligible_person, reindent=True)
     )
@@ -311,7 +312,7 @@ def create_pure_eligible_person(session):
     return result
 
 # Defines the criteria for an affiliate person to be Pure-eligible.
-def create_pure_eligible_affiliate(session):
+def create_view_pure_eligible_affiliate(session):
     result = session.execute(
         sqlparse.format(pure_eligible_affiliate_view, reindent=True)
     )
@@ -319,7 +320,7 @@ def create_pure_eligible_affiliate(session):
     return result
 
 # Defines the criteria for an employee person to be Pure-eligible.
-def create_pure_eligible_employee(session):
+def create_view_pure_eligible_employee(session):
     result = session.execute(
         sqlparse.format(pure_eligible_employee_view, reindent=True)
     )
@@ -327,7 +328,7 @@ def create_pure_eligible_employee(session):
     return result
 
 # All Pure-eligible jobs ever held by a Pure-eligible affiliate employee.
-def create_pure_eligible_affiliate_job(session):
+def create_view_pure_eligible_affiliate_job(session):
     result = session.execute(
         sqlparse.format(pure_eligible_affiliate_job_view, reindent=True)
     )
@@ -335,9 +336,19 @@ def create_pure_eligible_affiliate_job(session):
     return result
 
 # All Pure-eligible jobs ever held by a Pure-eligible employee.
-def create_pure_eligible_employee_job(session):
+def create_view_pure_eligible_employee_job(session):
     result = session.execute(
         sqlparse.format(pure_eligible_employee_job_view, reindent=True)
     )
     session.commit()
     return result
+# Returns a list of view creation method names (begin with create_)
+def _view_creation_methods():
+    return list(filter((lambda fn: fn.startswith('create_view_')), dir(sys.modules[__name__])))
+
+# Convenience method to call all view creation methods in this module
+def create_all_views(session):
+    results = {}
+    for fn in _view_creation_methods():
+        results[fn] = getattr(sys.modules[__name__], fn)(session)
+    return results

--- a/tests/test_dbviews.py
+++ b/tests/test_dbviews.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy import func
 from sqlalchemy.engine import ResultProxy
-from experts_dw import db, dbviews, models
+from experts_dw import db, dbviews
 from experts_dw.models import PureEligibleDemographics, PureEligiblePerson, PureEligibleAffiliateJob, PureEligibleEmployeeJob
 
 @pytest.fixture

--- a/tests/test_dbviews.py
+++ b/tests/test_dbviews.py
@@ -9,13 +9,13 @@ def session():
   with db.session('hotel') as session:
     yield session
 
-def test_list_view_creation_methods():
-  assert len(dbviews._view_creation_methods()) > 0
+def test_list_view_creation_functions():
+  assert len(dbviews._view_creation_functions()) > 0
 
 # Create all views
 def test_create_all_views(session):
   results = dbviews.create_all_views(session)
-  for fn in dbviews._view_creation_methods():
+  for fn in dbviews._view_creation_functions():
     assert isinstance(results[fn], ResultProxy)
 
 # Verify views with backing models return rows

--- a/tests/test_dbviews.py
+++ b/tests/test_dbviews.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy import func
 from sqlalchemy.engine import ResultProxy
-from experts_dw import db, dbviews
+from experts_dw import db, dbviews, models
 from experts_dw.models import PureEligibleDemographics, PureEligiblePerson, PureEligibleAffiliateJob, PureEligibleEmployeeJob
 
 @pytest.fixture
@@ -9,34 +9,22 @@ def session():
   with db.session('hotel') as session:
     yield session
 
-def test_pure_eligible_affiliate(session):
-  result = dbviews.create_pure_eligible_affiliate(session)
-  assert isinstance(result, ResultProxy)
+def test_list_view_creation_methods():
+  assert len(dbviews._view_creation_methods()) > 0
 
-def test_pure_eligible_employee(session):
-  result = dbviews.create_pure_eligible_employee(session)
-  assert isinstance(result, ResultProxy)
+# Create all views
+def test_create_all_views(session):
+  results = dbviews.create_all_views(session)
+  for fn in dbviews._view_creation_methods():
+    assert isinstance(results[fn], ResultProxy)
 
-def test_pure_eligible_demographics(session):
-  result = dbviews.create_pure_eligible_demographics(session)
-  assert isinstance(result, ResultProxy)
-  rows = session.query(func.count(PureEligibleDemographics.emplid)).scalar()
-  assert rows > 0
-
-def test_pure_eligible_person(session):
-  result = dbviews.create_pure_eligible_person(session)
-  assert isinstance(result, ResultProxy)
-  rows = session.query(func.count(PureEligiblePerson.emplid)).scalar()
-  assert rows > 0
-
-def test_pure_eligible_affiliate_job(session):
-  result = dbviews.create_pure_eligible_affiliate_job(session)
-  assert isinstance(result, ResultProxy)
-  rows = session.query(func.count(PureEligibleAffiliateJob.emplid)).scalar()
-  assert rows > 0
-
-def test_pure_eligible_employee_job(session):
-  result = dbviews.create_pure_eligible_employee_job(session)
-  assert isinstance(result, ResultProxy)
-  rows = session.query(func.count(PureEligibleEmployeeJob.emplid)).scalar()
-  assert rows > 0
+# Verify views with backing models return rows
+def test_view_rows(session):
+  for v in [
+      PureEligibleDemographics,
+      PureEligiblePerson,
+      PureEligibleAffiliateJob,
+      PureEligibleEmployeeJob
+  ]:
+    rows = session.query(func.count(v.emplid)).scalar()
+    assert rows > 0


### PR DESCRIPTION
Changes:
* All dbviews methods named `create_view_*` can be executed together with `experts_dw.dbviews.create_all_views(session)`
* Removes individual test methods for view creation. All are bundled into one test method which asserts the return of each.
* Validation that views return rows is bundled into a separate test method.