### PR TITLE
Add json column IS JSON constraints

### DIFF
--- a/alembic/versions/095d39509575_add_json_column_constraints.py
+++ b/alembic/versions/095d39509575_add_json_column_constraints.py
@@ -1,0 +1,28 @@
+"""add json column constraints
+
+Revision ID: 095d39509575
+Revises: 5df53f647a97
+Create Date: 2020-03-23 09:20:53.888738
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '095d39509575'
+down_revision = '5df53f647a97'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_check_constraint('ck_pure_json_organisation_json', 'pure_json_organisation', 'JSON IS JSON')
+    op.create_check_constraint('ck_pure_json_person_json', 'pure_json_person', 'JSON IS JSON')
+    op.create_check_constraint('ck_pure_json_research_output_json', 'pure_json_research_output', 'JSON IS JSON')
+
+
+def downgrade():
+    op.drop_constraint('ck_pure_json_organisation_json')
+    op.drop_constraint('ck_pure_json_person_json')
+    op.drop_constraint('ck_pure_json_research_output_json')

--- a/experts_dw/models.py
+++ b/experts_dw/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Table, Column, Boolean, DateTime, Integer, String, Text, create_engine, func, ForeignKey
+from sqlalchemy import Table, Column, Boolean, DateTime, Integer, String, Text, create_engine, func, ForeignKey, CheckConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref, relationship
@@ -14,6 +14,7 @@ Base = declarative_base(metadata=common.metadata)
 
 class PureJsonResearchOutput(Base):
   __tablename__ = 'pure_json_research_output'
+  __tableargs__ = (CheckConstraint('json IS JSON', name='ck_pure_json_research_output_json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -21,6 +22,7 @@ class PureJsonResearchOutput(Base):
 
 class PureJsonPerson(Base):
   __tablename__ = 'pure_json_person'
+  __tableargs__ = (CheckConstraint('json IS JSON', name='ck_pure_json_person_json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -28,6 +30,7 @@ class PureJsonPerson(Base):
 
 class PureJsonOrganisation(Base):
   __tablename__ = 'pure_json_organisation'
+  __tableargs__ = (CheckConstraint('json IS JSON', name='ck_pure_json_organisation_json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)


### PR DESCRIPTION
Adds column `json` check constraints `IS JSON` for json validation and makes them all queryable with Oracle json query methods (migration already run on tst)