### PR TITLE
Adds JSON column constraints on all PURE_API_ tables

### DIFF
--- a/alembic/versions/36e9e9794287_add_additional_json_column_constraints.py
+++ b/alembic/versions/36e9e9794287_add_additional_json_column_constraints.py
@@ -1,0 +1,32 @@
+"""Adds IS JSON column constraints to PURE_API_* tables
+
+Revision ID: 36e9e9794287
+Revises: 095d39509575
+Create Date: 2020-04-07 15:57:28.632614
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '36e9e9794287'
+down_revision = '3dca32d513ff'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_check_constraint('json', 'pure_api_pub', 'JSON IS JSON')
+    op.create_check_constraint('json', 'pure_api_internal_person', 'JSON IS JSON')
+    op.create_check_constraint('json', 'pure_api_external_person', 'JSON IS JSON')
+    op.create_check_constraint('json', 'pure_api_internal_org', 'JSON IS JSON')
+    op.create_check_constraint('json', 'pure_api_external_org', 'JSON IS JSON')
+
+
+def downgrade():
+    op.drop_constraint('ck_pure_api_pub_json', 'pure_api_pub')
+    op.drop_constraint('ck_pure_api_internal_person_json', 'pure_api_internal_person')
+    op.drop_constraint('ck_pure_api_external_person_json', 'pure_api_external_person')
+    op.drop_constraint('ck_pure_api_internal_org_json', 'pure_api_internal_org')
+    op.drop_constraint('ck_pure_api_external_org_json', 'pure_api_external_org')

--- a/experts_dw/models.py
+++ b/experts_dw/models.py
@@ -14,7 +14,7 @@ Base = declarative_base(metadata=common.metadata)
 
 class PureJsonResearchOutput(Base):
   __tablename__ = 'pure_json_research_output'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -22,7 +22,7 @@ class PureJsonResearchOutput(Base):
 
 class PureJsonPerson(Base):
   __tablename__ = 'pure_json_person'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -30,7 +30,7 @@ class PureJsonPerson(Base):
 
 class PureJsonOrganisation(Base):
   __tablename__ = 'pure_json_organisation'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -1042,7 +1042,7 @@ class PureApiChangeHst(Base):
 
 class PureApiPub(Base):
   __tablename__ = 'pure_api_pub'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1063,7 +1063,7 @@ class PureApiPubHst(Base):
 
 class PureApiInternalPerson(Base):
   __tablename__ = 'pure_api_internal_person'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1084,7 +1084,7 @@ class PureApiInternalPersonHst(Base):
 
 class PureApiExternalPerson(Base):
   __tablename__ = 'pure_api_external_person'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1105,7 +1105,7 @@ class PureApiExternalPersonHst(Base):
 
 class PureApiInternalOrg(Base):
   __tablename__ = 'pure_api_internal_org'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1126,7 +1126,7 @@ class PureApiInternalOrgHst(Base):
 
 class PureApiExternalOrg(Base):
   __tablename__ = 'pure_api_external_org'
-  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'),)
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)

--- a/experts_dw/models.py
+++ b/experts_dw/models.py
@@ -14,7 +14,7 @@ Base = declarative_base(metadata=common.metadata)
 
 class PureJsonResearchOutput(Base):
   __tablename__ = 'pure_json_research_output'
-  __tableargs__ = (CheckConstraint('json IS JSON', name='ck_pure_json_research_output_json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -22,7 +22,7 @@ class PureJsonResearchOutput(Base):
 
 class PureJsonPerson(Base):
   __tablename__ = 'pure_json_person'
-  __tableargs__ = (CheckConstraint('json IS JSON', name='ck_pure_json_person_json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)
@@ -30,7 +30,7 @@ class PureJsonPerson(Base):
 
 class PureJsonOrganisation(Base):
   __tablename__ = 'pure_json_organisation'
-  __tableargs__ = (CheckConstraint('json IS JSON', name='ck_pure_json_organisation_json'))
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text(), nullable=False)
   modified = Column(DateTime(), nullable=False)

--- a/experts_dw/models.py
+++ b/experts_dw/models.py
@@ -1042,6 +1042,7 @@ class PureApiChangeHst(Base):
 
 class PureApiPub(Base):
   __tablename__ = 'pure_api_pub'
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1062,6 +1063,7 @@ class PureApiPubHst(Base):
 
 class PureApiInternalPerson(Base):
   __tablename__ = 'pure_api_internal_person'
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1082,6 +1084,7 @@ class PureApiInternalPersonHst(Base):
 
 class PureApiExternalPerson(Base):
   __tablename__ = 'pure_api_external_person'
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1102,6 +1105,7 @@ class PureApiExternalPersonHst(Base):
 
 class PureApiInternalOrg(Base):
   __tablename__ = 'pure_api_internal_org'
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)
@@ -1122,6 +1126,7 @@ class PureApiInternalOrgHst(Base):
 
 class PureApiExternalOrg(Base):
   __tablename__ = 'pure_api_external_org'
+  __table_args__ = (CheckConstraint('json IS JSON', name='json'))
   uuid = Column(String(36), primary_key=True)
   json = Column(Text, nullable=False)
   modified = Column(DateTime, nullable=False, primary_key=True)


### PR DESCRIPTION
- Adds JSON column constraints on all `PURE_API_*` tables.
- Corrects a non-tuple syntax in models.py for existing `PURE_JSON_*` table constraints.